### PR TITLE
bugfix/chipid

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 ftdiflash
 ftdiflash.o
 ftdiflash.d
+*.exe


### PR DESCRIPTION
Fix JEDEC 9F command to only print 3 bytes